### PR TITLE
fix: using intel as a channel causes the installation to fail due to …

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -2,7 +2,6 @@ name: TrueConsense
 channels:
   - bioconda
   - conda-forge
-  - intel
   - anaconda
   - defaults
 dependencies:


### PR DESCRIPTION
…a HTTP 403 (Forbidden) error. As it is not required for the depencies it can safely be removed.